### PR TITLE
fix: disable MD060 table-column-style rule

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -18,5 +18,6 @@
   "MD046": false,
   "MD049": false,
   "MD050": false,
-  "MD051": false
+  "MD051": false,
+  "MD060": false
 }


### PR DESCRIPTION
## Summary

markdownlint-cli2 v23 (Dependabot PR #19) introduced `MD060/table-column-style` which requires spaces around every table pipe separator. All tables across the repo use compact style intentionally. The rule is not auto-fixable and enforcing it would produce 1,250 cosmetic-only diff lines across the content files with no educational benefit.

Adding `"MD060": false` to `.markdownlint.json` makes the lint check pass on PR #19 so it can be merged.

## Test plan

- [ ] Lint markdown files check passes on this PR
- [ ] PR #19 lint check passes after this merges to main