### PR TITLE
chore: housekeeping — README, CHANGELOG and linkcheck tidy

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -29,7 +29,6 @@ jobs:
             --exclude-path '.github'
             --exclude 'localhost'
             --exclude 'github.com/settings'
-            --exclude 'git-unlocked/discussions'
             --exclude 'gitlab.com/-/user_settings'
             --exclude 'account.microsoft.com'
             --exclude 'reddit.com'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,4 +166,5 @@ Practical scenarios showing Git in real professional contexts.
 
 [Unreleased]: https://github.com/zaccesss/git-unlocked/compare/v1.2.0...HEAD
 [1.2.0]: https://github.com/zaccesss/git-unlocked/releases/tag/v1.2.0
+[1.1.0]: https://github.com/zaccesss/git-unlocked/releases/tag/v1.1.0
 [1.0.0]: https://github.com/zaccesss/git-unlocked/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,24 @@ PATCH - typo fixes, small corrections, link updates
 
 ## [Unreleased]
 
-In progress or planned - not yet in a release.
+### Added
+
+- `.github/FUNDING.yml` - Patreon and Buy Me a Coffee support links
+- `.github/CODEOWNERS` - repository ownership declaration
+- `.github/DISCUSSION_TEMPLATE/` - four discussion templates: general questions, bug discussion, ideas and show-and-tell
+- `.github/dependabot.yml` - weekly Dependabot updates for GitHub Actions
+- `.github/workflows/stale.yml` - automatic stale issue and PR management
+- `.github/workflows/automerge-dependabot.yml` - auto-merge safe Dependabot patch and minor bumps
+
+### Fixed
+
+- Removed dead link to `graphite.com/blog/bitkeeper-linux-story-of-git-creation` (404) from `02-git/01-what-is-version-control.md`
+- Added `packagecontrol.io`, `blog.jetbrains.com` and `www.gnu.org/software/bash` to `.lycheeignore` to suppress intermittent CI timeouts and 500s from bot-blocking domains
+- Disabled `MD060/table-column-style` in `.markdownlint.json` following markdownlint-cli2 upgrade to v23
+
+---
+
+## Long-term plans
 
 - GitHub Pages site at zaccesss.github.io/git-unlocked
 - Interactive HTML quiz pages with instant answer checking
@@ -149,4 +166,5 @@ Practical scenarios showing Git in real professional contexts.
 
 [Unreleased]: https://github.com/zaccesss/git-unlocked/compare/v1.2.0...HEAD
 [1.2.0]: https://github.com/zaccesss/git-unlocked/releases/tag/v1.2.0
+[1.1.0]: https://github.com/zaccesss/git-unlocked/releases/tag/v1.1.0
 [1.0.0]: https://github.com/zaccesss/git-unlocked/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,5 +166,4 @@ Practical scenarios showing Git in real professional contexts.
 
 [Unreleased]: https://github.com/zaccesss/git-unlocked/compare/v1.2.0...HEAD
 [1.2.0]: https://github.com/zaccesss/git-unlocked/releases/tag/v1.2.0
-[1.1.0]: https://github.com/zaccesss/git-unlocked/releases/tag/v1.1.0
 [1.0.0]: https://github.com/zaccesss/git-unlocked/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > The most complete open source Git and version control course available. Free forever. MIT licensed.
 
 [![markdownlint](https://github.com/zaccesss/git-unlocked/actions/workflows/markdownlint.yml/badge.svg)](https://github.com/zaccesss/git-unlocked/actions/workflows/markdownlint.yml)
+[![Check Links](https://github.com/zaccesss/git-unlocked/actions/workflows/linkcheck.yml/badge.svg)](https://github.com/zaccesss/git-unlocked/actions/workflows/linkcheck.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Version](https://img.shields.io/badge/version-1.2.0-blue.svg)](CHANGELOG.md)
 
@@ -81,14 +82,6 @@ Open an [issue](https://github.com/zaccesss/git-unlocked/issues) in this reposit
 You can also reach me directly at [contact@isaacadjei.me](mailto:contact@isaacadjei.me) or via my [website contact page](https://isaacadjei.me/contact).
 
 ---
-
-## Contributors
-
-<p align="center">
-  <a href="https://github.com/zaccesss/git-unlocked/graphs/contributors">
-    <img src="https://contrib.rocks/image?repo=zaccesss/git-unlocked" alt="Contributors" />
-  </a>
-</p>
 
 ---
 


### PR DESCRIPTION
## Summary

- Remove contributors avatar block from README (contrib.rocks image)
- Add link check badge to README alongside the existing markdownlint badge
- Update CHANGELOG Unreleased section with CI fixes and new .github files added this session
- Add missing [1.1.0] footer link to CHANGELOG
- Separate long-term plans from recent unreleased changes in CHANGELOG
- Remove stale discussions exclusion from linkcheck.yml (Discussions is now enabled on the repo)