### PR TITLE
fix: update broken VS Code Copilot docs link

### DIFF
--- a/06-ides-and-editors/01-vs-code.md
+++ b/06-ides-and-editors/01-vs-code.md
@@ -483,7 +483,7 @@ VS Code ships a capable Git integration out of the box that handles staging at l
 - [GitLens pricing](https://www.gitkraken.com/pricing)
 - [GitHub Pull Requests extension repository](https://github.com/microsoft/vscode-pull-request-github)
 - [GitLab Workflow extension documentation](https://gitlab.com/gitlab-org/gitlab-vscode-extension)
-- [GitHub Copilot in VS Code documentation](https://code.visualstudio.com/docs/copilot/overview)
+- [GitHub Copilot in VS Code documentation](https://code.visualstudio.com/docs/agents/concepts/overview)
 - [GitHub Copilot pricing](https://github.com/features/copilot#pricing)
 
 ---


### PR DESCRIPTION
closes #23

The `/docs/copilot/overview` path on code.visualstudio.com now returns 404. VS Code restructured their AI docs and the equivalent overview page is now at `/docs/agents/concepts/overview`.