### PR TITLE
chore: add GitHub Sponsors to FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,3 @@
-patreon: zaccesss
+github: zaccesss
 buy_me_a_coffee: zaccesss
+patreon: zaccesss


### PR DESCRIPTION
closes #27

Adds `github: zaccesss` as the first entry in `.github/FUNDING.yml` and reorders so buy me a coffee comes before Patreon.