### PR TITLE
docs: add Zenodo DOI badge to README

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   linkchecker:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Check Links](https://github.com/zaccesss/git-unlocked/actions/workflows/linkcheck.yml/badge.svg)](https://github.com/zaccesss/git-unlocked/actions/workflows/linkcheck.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Version](https://img.shields.io/badge/version-1.2.0-blue.svg)](CHANGELOG.md)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20694984.svg)](https://doi.org/10.5281/zenodo.20694984)
 
 git-unlocked takes you from absolute zero to professional-level Git across every major platform: GitHub, GitLab, Bitbucket, Azure DevOps, Gitea, Forgejo and Codeberg. Every file covers Windows, Mac and Linux side by side. Nothing assumed. Nothing skipped.
 


### PR DESCRIPTION
closes #28

Adds the Zenodo DOI badge to the README header badge row linking to https://doi.org/10.5281/zenodo.20694984.

Also adds `workflow_dispatch` to the linkcheck workflow so it can be triggered manually to refresh the badge without waiting for Monday's scheduled run.