### PR TITLE
chore: release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ PATCH - typo fixes, small corrections, link updates
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-07-06
+
 ### Updated
 
 - Auto-merge now covers all Dependabot PRs including major bumps (previously only same-major patch/minor bumps merged), gated by the required CI checks, and any PR labelled `automerge`
@@ -36,6 +38,7 @@ PATCH - typo fixes, small corrections, link updates
 
 ### Fixed
 
+- Corrected the section count in `CITATION.cff` from 11 to 12 and aligned the file count with the README
 - Served the DOI badge from `img.shields.io` instead of `zenodo.org` so it renders reliably through GitHub's image proxy in the README
 - Excluded `oliviac.dev` and the `gitea.com` homepage from linkcheck, which kept timing out from CI runners despite the 30s timeout and retries (the `docs.gitea.com`, `dl.gitea.com` and `blog.gitea.com` subdomains stay checked)
 - Replaced dead GitLab Git cheat sheet PDF (404) with the maintained GitLab Git docs reference in `10-resources/index.md`
@@ -188,7 +191,8 @@ Practical scenarios showing Git in real professional contexts.
 
 ---
 
-[Unreleased]: https://github.com/zaccesss/git-unlocked/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/zaccesss/git-unlocked/compare/v1.2.1...HEAD
+[1.2.1]: https://github.com/zaccesss/git-unlocked/releases/tag/v1.2.1
 [1.2.0]: https://github.com/zaccesss/git-unlocked/releases/tag/v1.2.0
 [1.1.0]: https://github.com/zaccesss/git-unlocked/releases/tag/v1.1.0
 [1.0.0]: https://github.com/zaccesss/git-unlocked/releases/tag/v1.0.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,11 +1,11 @@
 cff-version: 1.2.0
 title: "git-unlocked: An Open-Source Modular Curriculum for Git and Version Control Education"
-version: 1.2.0
-date-released: "2026-06-15"
+version: 1.2.1
+date-released: "2026-07-06"
 abstract: >
   git-unlocked is an open-source modular curriculum for teaching Git and
-  version control principles. The repository comprises 202 files organised
-  across 11 thematic sections, covering topics from repository initialisation
+  version control principles. The repository comprises 217 files organised
+  across 12 thematic sections, covering topics from repository initialisation
   and branching strategies through to collaborative workflows and conflict
   resolution. Released under the MIT licence, it is designed to be freely
   reused, forked and extended by educators and self-directed learners.
@@ -33,7 +33,7 @@ preferred-citation:
       orcid: "https://orcid.org/0009-0001-8298-5098"
       affiliation: Aston University
   year: 2026
-  month: 6
+  month: 7
   publisher:
     name: Zenodo
   doi: "10.5281/zenodo.20694984"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![markdownlint](https://github.com/zaccesss/git-unlocked/actions/workflows/markdownlint.yml/badge.svg)](https://github.com/zaccesss/git-unlocked/actions/workflows/markdownlint.yml)
 [![Check Links](https://github.com/zaccesss/git-unlocked/actions/workflows/linkcheck.yml/badge.svg)](https://github.com/zaccesss/git-unlocked/actions/workflows/linkcheck.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.2.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.2.1-blue.svg)](CHANGELOG.md)
 [![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.20694984-blue.svg)](https://doi.org/10.5281/zenodo.20694984)
 
 git-unlocked takes you from absolute zero to professional-level Git across every major platform: GitHub, GitLab, Bitbucket, Azure DevOps, Gitea, Forgejo and Codeberg. Every file covers Windows, Mac and Linux side by side. Nothing assumed. Nothing skipped.


### PR DESCRIPTION
Cuts the **v1.2.1** patch release, rolling up everything fixed since v1.2.0.

## Included
- Linkcheck reliability: dead GitLab PDF replaced, flaky hosts (`oliviac.dev`, `gitea.com` homepage, `netflixtechblog.com`) excluded, 30s timeout. Full lychee audit is clean (0 errors, 0 timeouts).
- DOI badge now renders via `img.shields.io`.
- Auto-merge overhaul (covers major Dependabot bumps) plus a `Repo maintenance` branch-cleanup workflow, and `.gitignore`.
- CITATION.cff section count corrected to 12, file count aligned with README.
- Removed stray `oxford_scan.txt`.

## Release mechanics
- Version bumped to 1.2.1 in the README badge and CITATION.cff (date and citation month updated).
- CHANGELOG 1.2.1 section cut with compare links.
- After merge: the broken `v1.2.1` tag (pointing to an April commit) is deleted and re-created at this release, and a GitHub release is published.